### PR TITLE
datetime checker too deals with problematic cases of issue336

### DIFF
--- a/feature_engine/variable_manipulation.py
+++ b/feature_engine/variable_manipulation.py
@@ -170,6 +170,25 @@ def _find_or_check_categorical_variables(
     return variables
 
 
+def _is_categorical_and_is_datetime(column: pd.Series) -> bool:
+
+    # check for datetime only if object cannot be cast as numeric because
+    # if it could pd.to_datetime would convert it to datetime regardless
+    if is_object(column):
+        is_categorical_and_is_datetime = not is_numeric(
+            pd.to_numeric(column, errors="ignore")
+        ) and is_datetime(pd.to_datetime(column, errors="ignore", utc=True))
+
+    # check for datetime only if the type of the categories is not numeric
+    # because pd.to_datetime throws an error when it is an integer
+    elif is_categorical(column):
+        is_categorical_and_is_datetime = not is_numeric(
+            column.dtype.categories
+        ) and is_datetime(pd.to_datetime(column, errors="ignore", utc=True))
+
+    return is_categorical_and_is_datetime
+
+
 def _find_or_check_datetime_variables(
     X: pd.DataFrame, variables: Variables = None
 ) -> List[Union[str, int]]:
@@ -191,8 +210,7 @@ def _find_or_check_datetime_variables(
         variables = [
             column
             for column in X.select_dtypes(exclude="number").columns
-            if is_datetime(X[column])
-            or is_datetime(pd.to_datetime(X[column], errors="ignore", utc=True))
+            if is_datetime(X[column]) or _is_categorical_and_is_datetime(X[column])
         ]
 
         if len(variables) == 0:
@@ -202,7 +220,7 @@ def _find_or_check_datetime_variables(
 
         if is_datetime(X[variables]) or (
             not is_numeric(X[variables])
-            and is_datetime(pd.to_datetime(X[variables], errors="ignore", utc=True))
+            and _is_categorical_and_is_datetime(X[variables])
         ):
             variables = [variables]
         else:
@@ -218,12 +236,7 @@ def _find_or_check_datetime_variables(
                 column
                 for column in variables
                 if is_numeric(X[column])
-                or (
-                    not is_datetime(X[column])
-                    and not is_datetime(
-                        pd.to_datetime(X[column], errors="ignore", utc=True)
-                    )
-                )
+                or not _is_categorical_and_is_datetime(X[column])
             ]
 
             if len(vars_non_dt) > 0:

--- a/feature_engine/variable_manipulation.py
+++ b/feature_engine/variable_manipulation.py
@@ -238,7 +238,7 @@ def _find_or_check_datetime_variables(
         else:
             vars_non_dt = [
                 column
-                for column in variables
+                for column in X[variables].select_dtypes(exclude="datetime")
                 if is_numeric(X[column])
                 or not _is_categorical_and_is_datetime(X[column])
             ]


### PR DESCRIPTION
Since the logic for the datetime checker turned out to be fairly similar to that of the categorical checker, I tried to refactor as much as possible without affecting readability. This time it applies to all cases, even when the user specifies _variables_, right? We don't want to have variables such as [1,2,3] converted to 00:00:00 1970 or something because the user asked for it, do we

About the tests, the last ones I added are exactly the same for each of the cases where _Age_ is cast as _category_ and _int_. I was looking to maybe parametrize them but I believe that would require adding a separate test function just for those checks? I didn't just go ahead and do that because that file is designed with one test function per typechecker and that would be a little inconsistent with the rest, but maybe it is still worth it?

Finally is this large enough to belong to a separate issue? 